### PR TITLE
Ignore CHRONOS_VERSION in the list of args for Chronos

### DIFF
--- a/2.4.0/ubuntu/14.04/entrypoint.sh
+++ b/2.4.0/ubuntu/14.04/entrypoint.sh
@@ -3,7 +3,7 @@
 CMD="chronos run_jar"
 
 # Parse environment variables
-for env in $(set | grep ^CHRONOS_ | cut -d= -f1); do
+for env in $(set | grep ^CHRONOS_ | grep -v ^CHRONOS_VERSION | cut -d= -f1); do
     opt=$(echo "$env" | cut -d_ -f2- | tr '[:upper:]' '[:lower:]')
     arg=""; eval arg=\$"$env"
     CMD="$CMD --$opt $arg"


### PR DESCRIPTION
Chronos from mesoscloud/chronos:2.4.0-ubuntu-14.04 was failing because of the new environment variable CHRONOS_VERSION.

```
chronos run_jar --cluster_name federation_cluster --disable_after_failures 1 --failure_retry 5000 --hostname hbpfedqa1.intranet.chuv --http_port 4400 --master zk://hbpfedqa1.intranet.chuv:2181/mesos --version 2.4.0-0.1.20151007110204.ubuntu1404 --webui_url http://hbpfedqa1.intranet.chuv:4400/ --zk_hosts hbpfedqa1.intranet.chuv:2181
/usr/bin/chronos: line 18: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8): No such file or directory
[2016-09-27 07:56:50,117] INFO --------------------- (org.apache.mesos.chronos.scheduler.Main$:26)
[2016-09-27 07:56:50,119] INFO Initializing chronos. (org.apache.mesos.chronos.scheduler.Main$:27)
[2016-09-27 07:56:50,121] INFO --------------------- (org.apache.mesos.chronos.scheduler.Main$:28)
[scallop] Error: Unknown option 'version'
```

This patch should fix this problem.
